### PR TITLE
Migrate/repo

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -10,7 +10,7 @@ Types of Contributions
 Report Bugs
 ~~~~~~~~~~~
 
-Report bugs at https://github.com/mb-wali/invenio-theme-tugraz/issues.
+Report bugs at https://github.com/tu-graz-library/invenio-theme-tugraz/issues.
 
 If you are reporting a bug, please include:
 
@@ -41,7 +41,7 @@ Submit Feedback
 ~~~~~~~~~~~~~~~
 
 The best way to send feedback is to file an issue at
-https://github.com/mb-wali/invenio-theme-tugraz/issues.
+https://github.com/tu-graz-library/invenio-theme-tugraz/issues.
 
 If you are proposing a feature:
 
@@ -55,7 +55,7 @@ Get Started!
 
 Ready to contribute? Here's how to set up `invenio-theme-tugraz` for local development.
 
-1. Fork the `https://github.com/mb-wali/invenio-theme-tugraz.git` repo on GitHub.
+1. Fork the `https://github.com/tu-graz-library/invenio-theme-tugraz.git` repo on GitHub.
 2. Clone your fork locally:
 
    .. code-block:: console
@@ -114,5 +114,5 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring.
 3. The pull request should work for Python 2.7, 3.5 and 3.6. Check
-   https://travis-ci.com/github/mb-wali/invenio-theme-tugraz/pull_requests
+   https://travis-ci.com/github/tu-graz-library/invenio-theme-tugraz/pull_requests
    and make sure that the tests pass for all supported Python versions.

--- a/README.rst
+++ b/README.rst
@@ -9,17 +9,17 @@
  invenio-theme-tugraz
 ======================
 
-.. image:: https://travis-ci.com/mb-wali/invenio-theme-tugraz.svg
-        :target: https://travis-ci.com/github/mb-wali/invenio-theme-tugraz
+.. image:: https://travis-ci.com/tu-graz-library/invenio-theme-tugraz.svg
+        :target: https://travis-ci.com/github/tu-graz-library/invenio-theme-tugraz
 
 .. image:: https://img.shields.io/pypi/dm/invenio-theme-tugraz.svg
         :target: https://pypi.python.org/pypi/invenio-theme-tugraz
 
-.. image:: https://img.shields.io/github/tag/mb-wali/invenio-theme-tugraz.svg
-        :target: https://github.com/mb-wali/invenio-theme-tugraz/releases
+.. image:: https://img.shields.io/github/tag/tu-graz-library/invenio-theme-tugraz.svg
+        :target: https://github.com/tu-graz-library/invenio-theme-tugraz/releases
 
-.. image:: https://img.shields.io/github/license/mb-wali/invenio-theme-tugraz.svg
-        :target: https://github.com/mb-wali/invenio-theme-tugraz/blob/master/LICENSE
+.. image:: https://img.shields.io/github/license/tu-graz-library/invenio-theme-tugraz.svg
+        :target: https://github.com/tu-graz-library/invenio-theme-tugraz/blob/master/LICENSE
 
 .. image:: https://readthedocs.org/projects/invenio-theme-tugraz/badge/?version=latest
         :target: https://invenio-theme-tugraz.readthedocs.io/en/latest/?badge=latest

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -116,13 +116,13 @@ html_theme = "alabaster"
 
 html_theme_options = {
     "description": "invenio module for TUGRAZ theme.",
-    "github_user": "inveniosoftware",
+    "github_user": "TU Graz",
     "github_repo": "invenio-theme-tugraz",
     "github_button": False,
     "github_banner": True,
     "show_powered_by": False,
     "extra_nav_links": {
-        "invenio-theme-tugraz@GitHub": "https://github.com/mb-wali/invenio-theme-tugraz",
+        "invenio-theme-tugraz@GitHub": "https://github.com/tu-graz-library/invenio-theme-tugraz",
         "invenio-theme-tugraz@PyPI": "https://pypi.python.org/pypi/invenio-theme-tugraz/",
     },
 }

--- a/invenio_theme_tugraz/templates/invenio_theme_tugraz/navbar.html
+++ b/invenio_theme_tugraz/templates/invenio_theme_tugraz/navbar.html
@@ -58,7 +58,7 @@
     <div class="left floated left aligned six wide column" id="repo-logo">
       <div class="inline-elements">
         <div class="repo-img">
-          <img height="51.862" src="{{ url_for('static', filename='images/library_logo.png)}}">
+          <img height="51.862" src="{{ url_for('static', filename='images/library_logo.png')}}">
         </div>
         <div class="affiliation-text">
           <a title="RDM" href="{{url_for('invenio_theme_tugraz.index')}}">

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
     license="MIT",
     author="mojib wali",
     author_email="mojib.wali@tugraz.at",
-    url="https://github.com/mb-wali/invenio-theme-tugraz",
+    url="https://github.com/tu-graz-library/invenio-theme-tugraz",
     packages=packages,
     zip_safe=False,
     include_package_data=True,


### PR DESCRIPTION
Repository transfer from ```https://github.com/mb-wali``` to ```https://github.com/tu-graz-library```.

* updated badges
* readthedocs - URL paths 
* Setup.py repository URL