### PR TITLE
bugfix: adding flash messages for accounts template.

### DIFF
--- a/invenio_theme_tugraz/templates/invenio_theme_tugraz/accounts/accounts_base.html
+++ b/invenio_theme_tugraz/templates/invenio_theme_tugraz/accounts/accounts_base.html
@@ -67,6 +67,12 @@
 
     {%- block navbar_header %}
     {%- include "invenio_theme_tugraz/navbar.html" %}
+    <!--Flask messages for accounts-->
+    {%- block flashmessages %}
+    {%- from "invenio_theme/macros/messages.html" import flashed_messages with context -%}
+    {{ flashed_messages() }}
+
+    {%- endblock %}
     {%- endblock navbar_header %}
     
     {#


### PR DESCRIPTION
Since ```account_base.html``` template uses only navbar instead of full ```header.html```, the flash messages was missing.
with this PR the bug #122 is closed.