### PR TITLE
translations

### DIFF
--- a/invenio_theme_tugraz/translations/de/LC_MESSAGES/messages.po
+++ b/invenio_theme_tugraz/translations/de/LC_MESSAGES/messages.po
@@ -217,23 +217,23 @@ msgstr "Brauchen Sie Hilfe?"
 
 #: invenio_theme_tugraz/templates/invenio_theme_tugraz/index.html:123
 msgid "Contact us"
-msgstr "Erreichen Sie uns"
+msgstr "Kontaktiere uns"
 
 #: invenio_theme_tugraz/templates/invenio_theme_tugraz/index.html:127
 msgid "prioritizes all Recent uploads."
-msgstr "Reiht die neuesten Uploads vor"
+msgstr "Reiht die neuesten Uploads vor."
 
 #: invenio_theme_tugraz/templates/invenio_theme_tugraz/index.html:130
 msgid "We can help with:"
-msgstr "Dabei können wir Sie unterstützen"
+msgstr "Wir können helfen bei:"
 
 #: invenio_theme_tugraz/templates/invenio_theme_tugraz/index.html:135
 msgid "Uploading your research data, software, preprints, etc."
-msgstr "Hochladen Ihrer Forschungsdaten, Software, Preprints, etc."
+msgstr "Hochladen Ihrer Forschungsdaten, Software, Preprints usw."
 
 #: invenio_theme_tugraz/templates/invenio_theme_tugraz/index.html:136
 msgid "One-on-one with"
-msgstr "Eins zu eins mit"
+msgstr "Eins-zu-eins mit"
 
 #: invenio_theme_tugraz/templates/invenio_theme_tugraz/index.html:136
 msgid "supporters."
@@ -241,11 +241,11 @@ msgstr "Unterstützern"
 
 #: invenio_theme_tugraz/templates/invenio_theme_tugraz/index.html:137
 msgid "Quota increases beyond our default policy."
-msgstr "Erhöhung Ihres Kontingents über das vertraglich Zugesicherte hinaus"
+msgstr "Erhöhung Ihres Kontingents über das vertraglich Zugesicherte hinaus."
 
 #: invenio_theme_tugraz/templates/invenio_theme_tugraz/index.html:138
 msgid "Scripts for automated uploading of larger datasets."
-msgstr "Programme, die den automatischen Upload großer Datenmengen unterstützen"
+msgstr "Skripte zum automatisierten Hochladen größerer Datensätze."
 
 #: invenio_theme_tugraz/templates/invenio_theme_tugraz/index.html:143
 msgid "Why use"

--- a/invenio_theme_tugraz/translations/de/LC_MESSAGES/messages.po
+++ b/invenio_theme_tugraz/translations/de/LC_MESSAGES/messages.po
@@ -205,7 +205,7 @@ msgid ""
 "\n"
 "                Uploaded on %(date)s\n"
 "                "
-msgstr "Hochgeladen am"
+msgstr "Hochgeladen am %(date)s\n"
 
 #: invenio_theme_tugraz/templates/invenio_theme_tugraz/index.html:110
 msgid "More"

--- a/invenio_theme_tugraz/translations/de/LC_MESSAGES/messages.po
+++ b/invenio_theme_tugraz/translations/de/LC_MESSAGES/messages.po
@@ -288,7 +288,7 @@ msgstr "Ausloggen"
 
 #: invenio_theme_tugraz/templates/invenio_theme_tugraz/accounts/login_user.html:24
 msgid "Log in to Repository"
-msgstr "Ins repositorium einloggen"
+msgstr "Anmelden"
 
 #: invenio_theme_tugraz/templates/invenio_theme_tugraz/accounts/login_user.html:32
 #, python-format


### PR DESCRIPTION
## commits
* bugfix: adding missing (date) var.

## Todo
* add new commits if required changes.

## Open translations
* publication type (badge)
* /search page, there are multiple text fragments not translated. Like the "results per page", "View all versions", "Advanced search", "Search guide", "result(s) found" etc.
* should we translate "Uploads"?
* /uploads/new is also not translated as a whole
* /communities & /communities/new is also not translated yet
* rethink translations of:
  * "Ins repositorium einloggen": it sounds strange
  * "Erreichen Sie uns" -> "Kontaktiere uns" || "Kontaktformular"
  * all elements in the list of "Dabei können wir Sie unterstützen"
