### PR TITLE
ci: invenio-pytest

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,16 +1,33 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2020 mojib wali.
+# Copyright (C) 2019-2020 CERN.
+# Copyright (C) 2019-2020 Northwestern University.
+# Copyright (C) 2020 Graz University of Technology.
 #
 # invenio-theme-tugraz is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
 # details.
 
+
+# Quit on errors
+set -o errexit
+
+# Quit on unbound symbols
+set -o nounset
+
+# Always bring down docker services
+
+function cleanup() {
+    eval "$(docker-services-cli down --env)"
+}
+trap cleanup EXIT
+
+
 python -m check_manifest --ignore ".*-requirements.txt"
 python -m sphinx.cmd.build -qnNW docs docs/_build/html
-docker-services-cli --verbose up es postgresql redis
+eval "$(docker-services-cli up --db ${DB:-postgresql} --search ${SEARCH:-elasticsearch} --cache ${CACHE:-redis} --env)"
 python -m pytest
 tests_exit_code=$?
-docker-services-cli down
+python -m sphinx.cmd.build -qnNW -b doctest docs docs/_build/doctest
 exit "$tests_exit_code"

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ history = open("CHANGES.rst").read()
 tests_require = [
     "pytest-invenio>=1.4.0",
     'invenio-app>=1.3.0,<2.0.0',
+    "psycopg2-binary>=2.8.6",
 ]
 
 extras_require = {

--- a/setup.py
+++ b/setup.py
@@ -18,13 +18,11 @@ history = open("CHANGES.rst").read()
 tests_require = [
     "pytest-invenio>=1.4.0",
     'invenio-app>=1.3.0,<2.0.0',
-    # TODO: remove once a new release is out
-    'docker-services-cli>=0.2.1,<0.3.0'
 ]
 
 extras_require = {
     "docs": [
-        "Sphinx>=1.5.1",
+        "Sphinx>=3",
     ],
     "mysql": [
         "invenio-db[mysql]>=1.0.0",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,7 @@ from flask_babelex import Babel
 from invenio_db import InvenioDB, db
 from invenio_i18n import InvenioI18N
 from invenio_search import InvenioSearch
+from sqlalchemy_utils.functions import create_database, database_exists, drop_database
 
 from invenio_theme_tugraz import InvenioThemeTugraz
 


### PR DESCRIPTION
modified ```run-test.sh``` to newer invenio-pytest commands- which will now also run the tests written ```/test``` directory.

* removed docker-service-cli version restriction
* bump Sphinx version
* added missing imports (tests)