### PR TITLE
bugfix: search for published records.

### DIFF
--- a/invenio_theme_tugraz/search.py
+++ b/invenio_theme_tugraz/search.py
@@ -21,5 +21,5 @@ class FrontpageRecordsSearch(RecordsSearch):
     class Meta:
         """Default index and filter for frontpage search."""
 
-        index = "rdmrecords"
+        index = "rdmrecords-records"
         default_filter = Q("query_string", query=("access.access_right:open"))


### PR DESCRIPTION
After investigating - the quick and clean solution is to change the index to ```rdmrecords-records``` - which the correct way of searching for published records.
for more info on this see [here](https://github.com/inveniosoftware/invenio-rdm-records/blob/master/invenio_rdm_records/records/api.py)

This closes #126