### PR TITLE
fix: add trigger to accordion

### DIFF
--- a/invenio_theme_tugraz/templates/invenio_theme_tugraz/accounts/login_user.html
+++ b/invenio_theme_tugraz/templates/invenio_theme_tugraz/accounts/login_user.html
@@ -53,9 +53,9 @@
         {%- with form = login_user_form %}
         {%- set accordion_active = "active" if form.errors else "" %}
         <div class="ui styled accordion">
-          <div class="title {{ accordion_active }}">
+          <div class="title trigger {{ accordion_active }}">
             {{ _('Log in with repository credentials') }}
-            <i class="user icon"></i>
+            <i class="user icon button"></i>
           </div>
           <div class="content {{ accordion_active }}">
             <form action="{{ url_for_security('login') }}" method="POST" name="login_user_form" class="ui large form">

--- a/invenio_theme_tugraz/templates/invenio_theme_tugraz/accounts/register_user.html
+++ b/invenio_theme_tugraz/templates/invenio_theme_tugraz/accounts/register_user.html
@@ -61,9 +61,9 @@
         {%- set accordion_active = "active" if form.errors else "" %}
         <div class="ui padded centered large form">
           <div class="ui styled accordion">
-            <div class="title {{ accordion_active }}">
+            <div class="title trigger {{ accordion_active }}">
               {{ _('Sign up with repository credentials') }}
-              <i class="user icon"></i>
+              <i class="user icon button"></i>
             </div>
             <div class="content {{ accordion_active }}">
               <form class="ui large form" action="{{ url_for_security('register') }}" method="POST" name="register_user_form">


### PR DESCRIPTION
closes #264 
The functionality is now bound to the trigger class of the accordion.
Added `button` class to the icon, so it does not rotate on open/close