### PR TITLE
fix broken search page

### DIFF
--- a/invenio_theme_tugraz/templates/invenio_theme_tugraz/header.html
+++ b/invenio_theme_tugraz/templates/invenio_theme_tugraz/header.html
@@ -79,4 +79,23 @@
     {%- include "invenio_theme/breadcrumbs.html" %}
   {%- endblock breadcrumbs %}
   #}
+
+  <div style="display: none;">
+    {% include "invenio_app_rdm/searchbar.html" %}
+  </div>
+
+  <div class="ui container">
+    <div class="ui center aligned grid">
+      <div class="sixteen wide column">
+        <form action="{{config.THEME_SEARCH_ENDPOINT}}" class="ui form" role="search">
+          <div class="ui fluid big action icon input">
+            <input type="text" name="q" autofocus="autofocus" placeholder="{{ _("Type and press enter to search") }}">
+            <button type="submit" class="ui icon search button">
+              <i class="icon search"></i>
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
 </div>

--- a/invenio_theme_tugraz/templates/invenio_theme_tugraz/index.html
+++ b/invenio_theme_tugraz/templates/invenio_theme_tugraz/index.html
@@ -17,25 +17,8 @@
 {%- block page_body %}
 
 <div class="ui container">
-  {%- block frontpage_search %}
-
-  {%- block frontpage_form %}
-  <div class="ui center aligned grid">
-    <div class="sixteen wide column">
-      <form action="{{config.THEME_SEARCH_ENDPOINT}}" class="ui form" role="search">
-        <div class="ui fluid big action icon input">
-          <input type="text" name="q" autofocus="autofocus" placeholder="{{ _("Type and press enter to search") }}">
-          <button type="submit" class="ui icon search button">
-            <i class="icon search"></i>
-          </button>
-        </div>
-      </form>
-    </div>
-  </div>
   <div class="ui divider hidden"></div>
-  {%- endblock frontpage_form %}
 
-{%- endblock frontpage_search %}
   <div class="ui stackable grid">
 
     <!---Recent uploads-->


### PR DESCRIPTION
the invenioRDM version v9.1 introduced a new search feature. the implementation
assumes that the id header-search-bar exists on the page. if that is not the
case the page will not be rendered.

this fix adds a hidden search element as invenioRDM v9.1 introduced. the page is
not using this at the moment because it would need some further layout
adjustments.

further moves this fix the local search element to the header to be existent on
the index and search page. for the future this should be undone and the new
invenioRDM search should be used.
