### PR TITLE
login: redirect to next-url after login

### DIFF
--- a/invenio_theme_tugraz/templates/invenio_theme_tugraz/accounts/login_user.html
+++ b/invenio_theme_tugraz/templates/invenio_theme_tugraz/accounts/login_user.html
@@ -33,10 +33,11 @@
               {% endfor %}
             </div>
           {% endif %}
+          {% set next_url=request.args.get('next') or request.referrer %}
           {% if config.SSO_SAML_IDPS %}
             {% for name in config.SSO_SAML_IDPS.keys() %}
               <div class="field">
-                <a class="login-page-button ui fluid large button" href="{{ url_for('sso_saml.sso', idp=name) }}">
+                <a class="login-page-button ui fluid large button" href="{{ url_for('sso_saml.sso', idp=name, next=next_url) }}">
                   {{
                     _('Log in with %(title)s', title=config.SSO_SAML_IDPS[name]['title']|default("SAML", true))
                   }}
@@ -47,7 +48,8 @@
           {% endif %}
           {% if config.EDUGAIN_LOGIN_ENABLED %}
             <div class="field">
-              <a class="login-page-button ui fluid large button" href="{{ url_for('invenio_edugain.login_discover', next=request.args.get('next')) }}">
+              {% set return_url = url_for('invenio_edugain.authn_request', next=next_url, _external=True) %}
+              <a class="login-page-button ui fluid large button" href="{{ url_for('invenio_edugain.login_discover', **{'return': return_url}) }}">
                 {{ _('Log in with edugain') }}
                 <img src="{{ url_for('static', filename='icons/eduGAIN-FavIcon-transparent.png') }}" height="20px" />
               </a>


### PR DESCRIPTION
currently logging in either via TU Graz SSO or via edugain always redirects to homepage (`/`) after login

this fixes redirects after login for both of them


login endpoint sets `?next=<url-to-redirect-to-after-login>` to the URL as a query-string arg
login-template is supposed to pick this up and add it to the `href`s of buttons
(e.g. *Log in with TUGRAZ* button should have `href=https://repository.tugraz.at/shibboleth/login/idp?next=...`, but the `?next=...` part is currently not added)
(in the case of edugain, the underlying shibboleth-EDS requires something a bit more complicated)

`flask`'s `url_for` appends unknown kwargs to the created URL as query string args, making this quite easy