### PR TITLE
logging: update default error-handling

### DIFF
--- a/invenio_theme_tugraz/templates/invenio_theme_tugraz/default_error.html
+++ b/invenio_theme_tugraz/templates/invenio_theme_tugraz/default_error.html
@@ -9,13 +9,19 @@
   {% extends config.THEME_ERROR_TEMPLATE %}
 
   {% block message %}
-    <h1> {{ _('Internal server error') }} </h1>
-    <p>
+    <h1><i class="bolt icon"></i> {{ _('An unexpected error occured') }} </h1>
+    <div>
       {{ _(
           'Please contact <a href="mailto:{support_email}">our support</a>
           to let us know about this error.'
         ).format(support_email=config.THEME_TUGRAZ_SUPPORT_EMAIL)
       }}
-    </p>
+      <br>
+      {{ _('Please add to your email:') }}
+    </div>
+    <ul class="m-0">
+      <li>this error-id: <b>{{ error_id }}</b></li>
+      <li>a brief description of how you got to this error page</li>
+    </ul>
     {# TODO: provide g.sentry_event_id here once sentry is configured, cf. invenio_theme/500.html #}
   {% endblock message %}


### PR DESCRIPTION
update *html default error page* by adding an error-id and changing the wording to be more user-friendly
update logging done by `default_error_handler` to include the new error-id

NOTE: previous code used `traceback.format_exc()`, which formats the *currently active exception*
there's edge-cases where the *currently active exception* isn't the same as the passed-in exception `e`
using the passed-in `e` is correct in those edge cases