### PR TITLE
fix(ui): nested comments layout

### DIFF
--- a/invenio_theme_tugraz/assets/semantic-ui/less/invenio_theme_tugraz/overrides.less
+++ b/invenio_theme_tugraz/assets/semantic-ui/less/invenio_theme_tugraz/overrides.less
@@ -181,3 +181,11 @@ pre {
 .ui.flashed.message.manage {
   text-align: center;
 }
+
+.ui.feed .requests-event-item.selected > .requests-event-container.reply {
+  box-shadow: unset;
+}
+
+.ui.feed .requests-event-item.selected > .requests-event-container:not(.reply) > .requests-event-inner-container > .event {
+  box-shadow: unset;
+}


### PR DESCRIPTION
before:

<img width="600" height="687" alt="image" src="https://github.com/user-attachments/assets/c4a1a9de-9d99-43eb-8a36-8c8f5431b459" />


after:

<img width="605" height="687" alt="image" src="https://github.com/user-attachments/assets/7e9f4e2d-09eb-4cb6-b676-7268be056b34" />

